### PR TITLE
Correctly position miniplayer within the video.

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ miniplayer.innerHTML = `
   }
 </style>
 `;
-        document.body.appendChild(miniplayer);
+        document.querySelector(".media-screen").appendChild(miniplayer);
       }
     });
   })


### PR DESCRIPTION
Put the miniplayer inside the video screen element, instead of the bottom right corner of the page.